### PR TITLE
Use "ctrlc" package instead of unsafe blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/michieldwitte/reaper"
 [dependencies]
 nix = "0.26.1"
 libc = "0.2.139"
-signal-hook = "0.3.17"
+ctrlc = "3.4.1"
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 repository = "https://github.com/michieldwitte/reaper"
 
 [dependencies]
-nix = "0.26.1"
+nix = "0.27.1"
 libc = "0.2.139"
 ctrlc = "3.4.1"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,32 +5,16 @@ use std::ffi::CString;
 use std::path::Path;
 
 use libc::{prctl, PR_SET_CHILD_SUBREAPER};
-use nix::sys::signal::SigHandler;
-use nix::sys::signal::Signal;
 use nix::sys::wait::waitpid;
 use nix::unistd::{fork, execv, getpid, ForkResult, Pid};
-use nix::sys::signal::{kill, SIGKILL, SIGINT};
-use nix::sys::signal;
-
-static mut MAIN_PID : Option<Pid> = None;
+use nix::sys::signal::{kill, SIGKILL, SIGTERM};
 
 fn get_child_pids(process_id: Pid) -> Vec<Pid> {
 	let output = fs::read_to_string(format!("/proc/{process_id}/task/{process_id}/children")).expect("Failed to read out file");
-	return output.split(" ")
+	return output.split(' ')
 			.filter(|&x| !x.is_empty())
 			.map(|x| Pid::from_raw(x.parse::<i32>().unwrap()))
 			.collect();
-}
-
-extern fn handle_sigint(_signal: libc::c_int) {
-	unsafe {
-		let pid = MAIN_PID.expect("Could not get a pid");
-		match kill(pid, SIGINT) {
-			Ok(_) => (),
-			Err(error) => {println!("Could not kill pid {}, error: {}", pid, error);}
-		}
-	}
-
 }
 
 fn main() {
@@ -57,18 +41,23 @@ fn main() {
 		}
 	};
 
-	unsafe {MAIN_PID = Some(child_pid);}
+	ctrlc::set_handler(move || {
+		match kill(child_pid, SIGTERM) {
+			Ok(_) => (),
+			Err(error) => {println!("Could not kill pid {}, error: {}", child_pid, error);}
+		}
+	}).expect("Error setting Ctrl-C handler");
 
-	let handler = SigHandler::Handler(handle_sigint);
-	unsafe { signal::signal(Signal::SIGINT, handler) }.unwrap();
-
-	waitpid(child_pid, None).expect(format!("Waiting for main child process pid {child_pid} failed").as_str());
+	match waitpid(child_pid, None) {
+		Ok(_) => (),
+		Err(error) => {println!("Waiting for pid {} failed: {}", child_pid, error);}
+	}
 
 	let process_id = getpid();
 
 	loop {
 		let child_pids = get_child_pids(process_id);
-		if child_pids.len() == 0 {
+		if child_pids.is_empty() {
 			break;
 		}
 		for child_pid in child_pids {


### PR DESCRIPTION
Signalhandler should forward SIGINT and SIGTERM, ctrlc does this for us.

I fixed some linter warnings and updated a dependency while I was at it.